### PR TITLE
Add diagnostics for ovn-controller and OVN DBs

### DIFF
--- a/diagnostic_task.yml
+++ b/diagnostic_task.yml
@@ -1,0 +1,19 @@
+---
+
+- block:
+    - name: "execute diagnostic {{ item.name }} with command {{ item.command }}"
+      become: yes
+      ansible.builtin.shell: "{{ item.command }} | tr -d '\"'"
+      register: diagnostic_result
+  rescue:
+    - name: "diagnostic {{ item.name }} failed"
+      set_fact:
+        diagnostic_result:
+          stdout: FAILURE
+
+- debug:
+    var: diagnostic_result
+
+- ansible.builtin.set_fact:
+    node_results: "{{ node_results | default({}) | combine({item.name: diagnostic_result.stdout }) }}"
+

--- a/diagnostics_play.yml
+++ b/diagnostics_play.yml
@@ -1,0 +1,53 @@
+---
+- name: run OVN controller diagnostics
+  gather_facts: no
+  hosts: ovn_controller
+  vars:
+    diagnostics:
+      - name: ovn-remote-probe-interval
+        command: ovs-vsctl get open . external_ids:ovn-remote-probe-interval 
+      - name: ovn-openflow-probe-interval 
+        command: ovs-vsctl get open . external_ids:ovn-openflow-probe-interval
+      - name: ovn-monitor-all
+        command: ovs-vsctl get open . external_ids:ovn-monitor-all
+  tasks:
+    - name: run diagnostics
+      include_tasks: diagnostic_task.yml
+      loop: "{{ diagnostics }}"
+
+    - name: "store results from {{ inventory_hostname }}"
+      set_fact:
+        diagnostic_results: "{{ diagnostics_results | default({}) | combine({inventory_hostname: node_results }) }}" 
+
+        #    - debug:
+        #        var: diagnostic_results
+
+
+- name: run OVN DBs diagnostics
+  gather_facts: no
+  hosts: ovn_dbs
+  vars:
+    diagnostics:
+      - name: nb-inactivity-probe
+        command: podman exec $(podman ps -qf name=ovn-dbs-bundle) ovn-nbctl get connection . inactivity_probe
+      - name: sb-inactivity-probe 
+        command: podman exec $(podman ps -qf name=ovn-dbs-bundle) ovn-sbctl get connection . inactivity_probe
+      - name: datapath-grouping
+        command: podman exec $(podman ps -qf name=ovn-dbs-bundle) ovn-nbctl get nb_global . options:use_logical_dp_groups
+  tasks:
+    - name: run diagnostics
+      include_tasks: diagnostic_task.yml
+      loop: "{{ diagnostics }}"
+
+    - name: "store results from {{ inventory_hostname }}"
+      set_fact:
+        diagnostic_results: "{{ diagnostics_results | default({}) | combine({inventory_hostname: node_results }) }}" 
+
+
+- name: print results
+  gather_facts: no
+  hosts: ovn_controller, ovn_dbs
+  tasks:
+    - debug:
+        var: diagnostic_results
+

--- a/ovn-diagnostic.sh
+++ b/ovn-diagnostic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2022 Red Hat, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,38 +15,27 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-# With LANG set to everything else than C completely undercipherable errors
-# like "file not found" and decoding errors will start to appear during scripts
-# or even ansible modules
-LANG=C
-
 # Complete stackrc file path.
 : ${STACKRC_FILE:=~/stackrc}
 
-# Complete overcloudrc file path.
-: ${OVERCLOUDRC_FILE:=~/overcloudrc}
-
-# user on the nodes in the undercloud
-: ${UNDERCLOUD_NODE_USER:=heat-admin}
-
-: ${OPT_WORKDIR:=$PWD}
 : ${STACK_NAME:=overcloud}
 : ${OOO_WORKDIR:=$HOME/overcloud-deploy}
 
-# Generate the ansible.cfg file
-generate_ansible_config_file() {
+SCRIPT_DIR=$(dirname $0)
 
-    cat > ansible.cfg <<-EOF
+# Generate the ansible.cfg file
+function generate_ansible_config_file() {
+
+    cat > $SCRIPT_DIR/ansible.cfg <<-EOF
 [defaults]
 forks=50
-become=True
 callback_whitelist = profile_tasks
 host_key_checking = False
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = ./ansible_facts_cache
 fact_caching_timeout = 0
-log_path = $HOME/ovn-diagnostic-ansible.log
+log_path = $SCRIPT_DIR/ovn-diagnostic-ansible.log
 #roles_path = roles:...
 [ssh_connection]
 control_path = %(directory)s/%%h-%%r
@@ -54,69 +43,33 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=270s -o ServerAliveInterval=3
 retries = 3
 EOF
 
-
-# Generate the inventory file for ansible diagnostic playbooks.
-generate_ansible_inventory_file() {
-    local inventory_file
-
-    echo "Generating the inventory file for ansible-playbook"
-    echo "[ovn-dbs]"  > hosts_to_diagnose
-    ovn_central=True
-
-    if [ -f /usr/bin/tripleo-ansible-inventory ]; then
-        source $STACKRC_FILE
-        inventory_file=$(mktemp --tmpdir ansible-inventory-XXXXXXXX.yaml)
-        /usr/bin/tripleo-ansible-inventory --stack $STACK_NAME --static-yaml-inventory "$inventory_file"
-    else
-        local inventory_file="$OOO_WORKDIR/$STACK_NAME/config-download/$STACK_NAME/tripleo-ansible-inventory.yaml"
-    fi
-
-    # We want to run ovn_dbs where neutron_api is running
-    OVN_DBS=$(get_group_hosts "$inventory_file" neutron_api)
-    for node_name in $OVN_DBS; do
-        node_ip=$(get_host_ip "$inventory_file" $node_name)
-        node="$node_name ansible_host=$node_ip"
-        if [ "$ovn_central" == "True" ]; then
-            ovn_central=False
-            node="$node_name ansible_host=$node_ip ovn_central=true"
-        fi
-        echo $node ansible_ssh_user=$UNDERCLOUD_NODE_USER ansible_become=true >> hosts_to_diagnose
-    done
-
-    echo "" >> hosts_to_diagnose
-    echo "[ovn-controllers]" >> hosts_to_diagnose
-
-    OVN_CONTROLLERS=$(get_group_hosts "$inventory_file" ovn_controller)
-    for node_name in $OVN_CONTROLLERS; do
-        node_ip=$(get_host_ip "$inventory_file" $node_name)
-        echo $node_name ansible_host=$node_ip
-        ansible_ssh_user=$UNDERCLOUD_NODE_USER ansible_become=true ovn_controller=true >> hosts_to_diagnose
-    done
-
-    echo "" >> hosts_to_diagnose
-
-    cat >> hosts_to_diagnose << EOF
-[overcloud:children]
-ovn-controllers
-ovn-dbs
-EOF
-    add_group_vars() {
-
-    cat >> hosts_to_diagnose << EOF
-[$1:vars]
-remote_user=$UNDERCLOUD_NODE_USER
-overcloudrc=$OVERCLOUDRC_FILE
-EOF
-    }
-
-    add_group_vars overcloud
-    add_group_vars overcloud-controllers
-
-
-    echo "***************************************"
-    cat hosts_to_diagnose
-    echo "***************************************"
-    echo "Generated the inventory file - hosts_to_diagnose"
-    echo "Please review the file before running the next command - setup-mtu-t1"
 }
 
+
+# Generate the inventory file for ansible diagnostic playbooks.
+function get_ansible_inventory_file() {
+    local work_dir=$1
+    local inventory_file=$work_dir/inventory.yaml
+
+    if [ ! -f $inventory_file ]; then
+        inventory_file="$OOO_WORKDIR/$STACK_NAME/config-download/$STACK_NAME/tripleo-ansible-inventory.yaml"
+	if [ ! -f $inventory_file ]; then
+            source $STACKRC_FILE
+            inventory_file=$work_dir/inventory.yaml
+            /usr/bin/tripleo-ansible-inventory --stack $STACK_NAME --static-yaml-inventory "$inventory_file"
+	fi
+    fi
+
+    echo $inventory_file
+}
+
+
+function main() {
+    inventory_file=$(get_ansible_inventory_file $SCRIPT_DIR)
+
+    pushd $SCRIPT_DIR
+    ansible-playbook -i $inventory_file -e working_dir="$SCRIPT_DIR" diagnostics_play.yml 
+    popd
+}
+
+main


### PR DESCRIPTION
The patch adds the main functionality. There is generic diagnostics
module containing tasks to run specified commands and storing them. Then
this is executed per every diagnostic. Each play is per set for set of
nodes (ovn-controller and OVN DBs). The plays store collected values
that are printed at the end.

Signed-off-by: Jakub Libosvar <libosvar@redhat.com>